### PR TITLE
Bugfix: range anxiety cost was mistakingly overwritten.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTrpLib
 Title: Helper functions for EDGE transport calculations
-Version: 0.1.7
+Version: 0.1.8
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))		    
@@ -17,5 +17,5 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.0
-Date: 2020-06-17
-ValidationKey: 313310
+Date: 2020-06-25
+ValidationKey: 331884

--- a/R/calculate_logit_inconv_endog.R
+++ b/R/calculate_logit_inconv_endog.R
@@ -300,21 +300,23 @@ calculate_logit_inconv_endog = function(prices,
                            prange), by = c("iso", "technology", "vehicle_type", "subsector_L1")]
 
       ## the phase-in of BEVs should not be too abrupt
-      if (t <= 2025) {
-        mult = 0.8
-      } else if (t > 2025 & t < 2028) {
-        mult = 0.6
-      } else if (t >= 2028 & t <=2030) {
-        mult = 0.4
-      } else if (t >2030 & t <= 2033) {
-        mult = 0.2
-      } else {
-        mult = 1
-      }
+      if (t <= 2033) {
 
-      tmp[technology == "BEV", prange :=ifelse(year == t,
-                                              pmax(mult*prange[year == 2020], prange),
-                                              prange), by = c("iso", "technology", "vehicle_type", "subsector_L1")]
+        if (t <= 2025) {
+          mult = 0.8
+        } else if (t > 2025 & t < 2028) {
+          mult = 0.6
+        } else if (t >= 2028 & t <=2030) {
+          mult = 0.4
+        } else if (t >2030 & t <= 2033) {
+          mult = 0.2
+        }
+
+        tmp[technology == "BEV", prange :=ifelse(year == t,
+                                                 pmax(mult*prange[year == 2020], prange),
+                                                 prange), by = c("iso", "technology", "vehicle_type", "subsector_L1")]
+
+      }
 
       if (techswitch == "FCEV") {
         ## the policymaker pushes carmakers and car retailers to provide FCEVs models, resulting in a decrease in model availability cost for H2 vehicles


### PR DESCRIPTION
This pull request should fix a bug in the phase-in of BEVs. Range anxiety costs are now free to decrease instead of being overwritten.