### PR TITLE
Change logit structure for cycling and walking

### DIFF
--- a/R/calculate_logit_inconv_endog.R
+++ b/R/calculate_logit_inconv_endog.R
@@ -47,7 +47,7 @@ calculate_logit_inconv_endog = function(prices,
     ## delete entries have tot_price NA (e.g. 1900 BEV)
     df <- df[ !(is.na(tot_price))]
     ## entries that are not present in the mix have non_fuel_price == 0, but also Walk and Cycle: delete all the not-present in the mix options
-    df <- df[(non_fuel_price>0)|(non_fuel_price==0 & subsector_L3 %in% c("Walk", "Cycle"))]
+    df <- df[(non_fuel_price>0)|(non_fuel_price==0 & subsector_L1 %in% c("Walk", "Cycle"))]
     ## needs random lambdas for the sectors that are not explicitly calculated
     df <- df[ is.na(logit.exponent), logit.exponent := -10]
 
@@ -134,7 +134,7 @@ calculate_logit_inconv_endog = function(prices,
     ## delete entries have tot_price NA (e.g. 1900 BEV)
     df <- df[ !(is.na(tot_price))]
     ## entries that are not present in the mix have non_fuel_price == 0, but also Walk and Cycle: delete all the not-present in the mix options
-    df <- df[(non_fuel_price>0)|(non_fuel_price==0 & subsector_L3 %in% c("Walk", "Cycle"))]
+    df <- df[(non_fuel_price>0)|(non_fuel_price==0 & subsector_L1 %in% c("Walk", "Cycle"))]
     ## needs random lambdas for the sectors that are not explicitly calculated
     df <- df[ is.na(logit.exponent), logit.exponent := -10]
 

--- a/edgetRansport.Rproj
+++ b/edgetRansport.Rproj
@@ -5,7 +5,12 @@ SaveWorkspace: No
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
 Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes


### PR DESCRIPTION
Logit structure was changed as follows:

Subsector_L3: "Walk" & "Cycle" -> "trn_pass_road"
Subsector_L2: "Walk_tmp_subsector_L2" & "Cycle_tmp_subsector_L2" -> "Non_mot"
Subsector_L1: "Walk_tmp_subsector_L1" & "Cycle_tmp_subsector_L1" -> "Walk" & "Cycle"

Note: Some changes are still missing