### PR TITLE
Hofix related to an issue when trying to detect a start year for sensible price signals

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '398496'
+ValidationKey: '417494'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "edgeTrpLib: Helper functions for EDGE transport calculations",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "<p>This package is highly specialized and created solely to not duplicate helper functions.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTrpLib
 Title: Helper functions for EDGE transport calculations
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))		    
@@ -18,6 +18,6 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.2
-Date: 2021-12-15
+Date: 2021-12-16
 Suggests: 
     covr

--- a/R/merge_prices.R
+++ b/R/merge_prices.R
@@ -28,6 +28,9 @@ merge_prices <- function(gdx, REMINDmapping, REMINDyears,
     ## load entries from the gdx, values below 2020 do not make sense
     pfe <- readGDX(gdx, "pm_FEPrice", format = "first_found", restore_zeros = FALSE)[,, "trans.ES", pmatch=TRUE]
     startyear <- getYears(pfe, as.integer=TRUE)[1]
+    if(startyear < 2020){
+        startyear <- 2020
+    }
     years <- REMINDyears[REMINDyears >= startyear]
     ## smooth prices
     pfe <- pfe[, years] %>% lowpass() %>% magpie2dt()

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Helper functions for EDGE transport calculations
 
-R package **edgeTrpLib**, version **0.2.1**
+R package **edgeTrpLib**, version **0.2.2**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/edgeTrpLib)](https://cran.r-project.org/package=edgeTrpLib)  [![R build status](https://gitlab.pik-potsdam.de/REMIND/edgetrplib/workflows/check/badge.svg)](https://gitlab.pik-potsdam.de/REMIND/edgetrplib/actions) [![codecov](https://codecov.io/gh/REMIND/edgetrplib/branch/master/graph/badge.svg)](https://codecov.io/gh/REMIND/edgetrplib) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTrpLib)](https://pik-piam.r-universe.dev/ui#builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/edgeTrpLib)](https://cran.r-project.org/package=edgeTrpLib)  [![R build status](https://github.com/Loisel/edgeTrpLib/workflows/check/badge.svg)](https://github.com/Loisel/edgeTrpLib/actions) [![codecov](https://codecov.io/gh/Loisel/edgeTrpLib/branch/master/graph/badge.svg)](https://codecov.io/gh/Loisel/edgeTrpLib) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTrpLib)](https://pik-piam.r-universe.dev/ui#builds)
 
 ## Purpose and Functionality
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTrpLib** in publications use:
 
-Dirnaichner A, Rottoli M (2021). _edgeTrpLib: Helper functions for EDGE transport calculations_. R package version 0.2.1.
+Dirnaichner A, Rottoli M (2021). _edgeTrpLib: Helper functions for EDGE transport calculations_. R package version 0.2.2.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,6 +47,6 @@ A BibTeX entry for LaTeX users is
   title = {edgeTrpLib: Helper functions for EDGE transport calculations},
   author = {Alois Dirnaichner and Marianna Rottoli},
   year = {2021},
-  note = {R package version 0.2.1},
+  note = {R package version 0.2.2},
 }
 ```


### PR DESCRIPTION
It turns out that the parameter `pm_FEPrice` is (sometimes) non-zero for years down to 2005. I do not know why, but we make sure that we do not use prices before 2020.