### PR TITLE
Fix createRDS

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^codecov\.yml$
 ^\.git$
 ^\.pre-commit-config\.yaml$
+^workflow$

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '588411'
+ValidationKey: '608800'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "edgeTrpLib: Helper functions for EDGE transport calculations",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "<p>This package is highly specialized and created solely to not duplicate helper functions.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTrpLib
 Title: Helper functions for EDGE transport calculations
-Version: 0.3.1
+Version: 0.3.2
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))		    
@@ -18,6 +18,6 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.2
-Date: 2021-12-20
+Date: 2022-02-02
 Suggests: 
     covr

--- a/R/createRDS.R
+++ b/R/createRDS.R
@@ -17,7 +17,10 @@ createRDS <- function(input_path, data_path, SSP_scenario, EDGE_scenario){
 
   ## function that loads the csv input files and converts them into RDS local files
   csv2RDS = function(pattern, filename, input_path, names_dt){
-    tmp=fread(paste0(input_path, pattern, ".cs4r"), stringsAsFactors = FALSE, col.names = names_dt, skip = 4)[SSPscen == SSP_scenario & EDGEscen == EDGE_scenario][, -c("SSPscen", "EDGEscen")]
+    tmp <- fread(
+      paste0(input_path, pattern, ".cs4r"),
+      col.names = names_dt, skip="gdp_"
+    )[SSPscen == SSP_scenario & EDGEscen == EDGE_scenario][, -c("SSPscen", "EDGEscen")]
     tmp[,vehicle_type := gsub("DOT", ".", vehicle_type)]
     tmp_list <- split(tmp,tmp$entry)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Helper functions for EDGE transport calculations
 
-R package **edgeTrpLib**, version **0.3.1**
+R package **edgeTrpLib**, version **0.3.2**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/edgeTrpLib)](https://cran.r-project.org/package=edgeTrpLib)  [![R build status](https://gitlab.pik-potsdam.de/REMIND/edgetrplib/workflows/check/badge.svg)](https://gitlab.pik-potsdam.de/REMIND/edgetrplib/actions) [![codecov](https://codecov.io/gh/REMIND/edgetrplib/branch/master/graph/badge.svg)](https://codecov.io/gh/REMIND/edgetrplib) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTrpLib)](https://pik-piam.r-universe.dev/ui#builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/edgeTrpLib)](https://cran.r-project.org/package=edgeTrpLib)  [![R build status](https://gitlab.pik-potsdam.de/REMIND/edgetrplib/workflows/check/badge.svg)](https://gitlab.pik-potsdam.de/REMIND/edgetrplib/actions) [![codecov](https://codecov.io/gh/REMIND/edgetrplib/branch/master/graph/badge.svg)](https://app.codecov.io/gh/REMIND/edgetrplib) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTrpLib)](https://pik-piam.r-universe.dev/ui#builds)
 
 ## Purpose and Functionality
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTrpLib** in publications use:
 
-Dirnaichner A, Rottoli M (2021). _edgeTrpLib: Helper functions for EDGE transport calculations_. R package version 0.3.1.
+Dirnaichner A, Rottoli M (2022). _edgeTrpLib: Helper functions for EDGE transport calculations_. R package version 0.3.2.
 
 A BibTeX entry for LaTeX users is
 
@@ -46,7 +46,7 @@ A BibTeX entry for LaTeX users is
 @Manual{,
   title = {edgeTrpLib: Helper functions for EDGE transport calculations},
   author = {Alois Dirnaichner and Marianna Rottoli},
-  year = {2021},
-  note = {R package version 0.3.1},
+  year = {2022},
+  note = {R package version 0.3.2},
 }
 ```


### PR DESCRIPTION
Warnings were produced since skipping 4 lines in cs4r is not enough for *some* files (all except one). With the patch we look for the string `gdp_` which is part of the GDP scenario column in all files to start reading.

Related to issue #46 