### PR TITLE
Add ldv differentitation to comp scen

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2676520'
+ValidationKey: '2868150'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "edgeTrpLib: Helper functions for EDGE transport calculations",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "<p>This package is highly specialized and created solely to not duplicate helper functions.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTrpLib
 Title: Helper functions for EDGE transport calculations
-Version: 1.4.0
+Version: 1.5.0
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))		    
@@ -23,6 +23,6 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.2
-Date: 2022-05-06
+Date: 2022-05-09
 Suggests: 
     covr

--- a/R/reportEDGETransport2.R
+++ b/R/reportEDGETransport2.R
@@ -401,7 +401,7 @@ reportEDGETransport2 <- function(output_folder = ".", sub_folder = "EDGE-T/",
       toMIF[region %in% regionSubsetList[["EUR"]], .(value = sum(value), region = "EUR"), by = .(model, scenario, variable, unit, period)],
       toMIF[region %in% regionSubsetList[["NEU"]], .(value = sum(value), region = "NEU"), by = .(model, scenario, variable, unit, period)],
       toMIF[region %in% regionSubsetList[["EU27"]], .(value = sum(value), region = "EU27"), by = .(model, scenario, variable, unit, period)],
-      toMIF[, .(value = sum(value), region = "GLO"), by = .(model, scenario, variable, unit, period)]
+      toMIF[, .(value = sum(value), region = "World"), by = .(model, scenario, variable, unit, period)]
     ), use.names=TRUE)
   }
 
@@ -729,11 +729,11 @@ reportEDGETransport2 <- function(output_folder = ".", sub_folder = "EDGE-T/",
           POP[region %in% regionSubsetList[["EUR"]], .(value = sum(value), region = "EUR"), by = .(model, scenario, variable, unit, period)],
           POP[region %in% regionSubsetList[["NEU"]], .(value = sum(value), region = "NEU"), by = .(model, scenario, variable, unit, period)],
           POP[region %in% regionSubsetList[["EU27"]], .(value = sum(value), region = "EU27"), by = .(model, scenario, variable, unit, period)],
-          POP[, .(value = sum(value), region = "GLO"), by = .(model, scenario, variable, unit, period)],
+          POP[, .(value = sum(value), region = "World"), by = .(model, scenario, variable, unit, period)],
           GDP[region %in% regionSubsetList[["EUR"]], .(value = sum(value), region = "EUR"), by = .(model, scenario, variable, unit, period)],
           GDP[region %in% regionSubsetList[["NEU"]], .(value = sum(value), region = "NEU"), by = .(model, scenario, variable, unit, period)],
           GDP[region %in% regionSubsetList[["EU27"]], .(value = sum(value), region = "EU27"), by = .(model, scenario, variable, unit, period)],
-          GDP[, .(value = sum(value), region = "GLO"), by = .(model, scenario, variable, unit, period)]
+          GDP[, .(value = sum(value), region = "World"), by = .(model, scenario, variable, unit, period)]
         ), use.names=TRUE)
       }
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Helper functions for EDGE transport calculations
 
-R package **edgeTrpLib**, version **1.4.0**
+R package **edgeTrpLib**, version **1.5.0**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/edgeTrpLib)](https://cran.r-project.org/package=edgeTrpLib)  [![R build status](https://gitlab.pik-potsdam.de/REMIND/edgetrplib/workflows/check/badge.svg)](https://gitlab.pik-potsdam.de/REMIND/edgetrplib/actions) [![codecov](https://codecov.io/gh/REMIND/edgetrplib/branch/master/graph/badge.svg)](https://app.codecov.io/gh/REMIND/edgetrplib) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTrpLib)](https://pik-piam.r-universe.dev/ui#builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/edgeTrpLib)](https://cran.r-project.org/package=edgeTrpLib)  [![R build status](https://github.com/johannah-pik/edgeTrpLib/workflows/check/badge.svg)](https://github.com/johannah-pik/edgeTrpLib/actions) [![codecov](https://codecov.io/gh/johannah-pik/edgeTrpLib/branch/master/graph/badge.svg)](https://app.codecov.io/gh/johannah-pik/edgeTrpLib) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTrpLib)](https://pik-piam.r-universe.dev/ui#builds)
 
 ## Purpose and Functionality
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTrpLib** in publications use:
 
-Dirnaichner A, Rottoli M (2022). _edgeTrpLib: Helper functions for EDGE transport calculations_. R package version 1.4.0.
+Dirnaichner A, Rottoli M (2022). _edgeTrpLib: Helper functions for EDGE transport calculations_. R package version 1.5.0.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,6 +47,6 @@ A BibTeX entry for LaTeX users is
   title = {edgeTrpLib: Helper functions for EDGE transport calculations},
   author = {Alois Dirnaichner and Marianna Rottoli},
   year = {2022},
-  note = {R package version 1.4.0},
+  note = {R package version 1.5.0},
 }
 ```

--- a/inst/extdata/EDGETdataAggregation.csv
+++ b/inst/extdata/EDGETdataAggregation.csv
@@ -1,84 +1,84 @@
-sector,subsector_L3,subsector_L2,subsector_L1,vehicle_type,technology,aggr_mode,aggr_LDV,aggr_veh,nonmot,aggr_nonmot,det_veh,aggr_bunkers
-Freight,Domestic Ship,Domestic Ship_tmp_subsector_L2,Domestic Ship_tmp_subsector_L1,Domestic Ship_tmp_vehicletype,Liquids,NA,NA,Freight|Navigation,NA,NA,NA,Freight|w/o bunkers
-Freight,Freight Rail,Freight Rail_tmp_subsector_L2,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_vehicletype,Electric,NA,NA,Freight|Rail,NA,NA,NA,Freight|w/o bunkers
-Freight,Freight Rail,Freight Rail_tmp_subsector_L2,Freight Rail_tmp_subsector_L1,Freight Rail_tmp_vehicletype,Liquids,NA,NA,Freight|Rail,NA,NA,NA,Freight|w/o bunkers
-Freight,International Ship,International Ship_tmp_subsector_L2,International Ship_tmp_subsector_L1,International Ship_tmp_vehicletype,Liquids,NA,NA,Freight|International Shipping,NA,NA,NA,NA
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (0-3.5t),Electric,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (0-3.5t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (0-3.5t),FCEV,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (0-3.5t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (0-3.5t),Liquids,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (0-3.5t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (0-3.5t),NG,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (0-3.5t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (18t),Electric,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (18t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (18t),FCEV,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (18t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (18t),Liquids,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (18t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (18t),NG,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (18t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (26t),Electric,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (26t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (26t),FCEV,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (26t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (26t),Liquids,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (26t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (26t),NG,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (26t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (40t),Electric,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (40t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (40t),FCEV,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (40t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (40t),Liquids,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (40t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (40t),NG,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (40t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (7.5t),Electric,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (7.5t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (7.5t),FCEV,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (7.5t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (7.5t),Liquids,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (7.5t),Freight|w/o bunkers
-Freight,trn_freight_road,trn_freight_road_tmp_subsector_L2,trn_freight_road_tmp_subsector_L1,Truck (7.5t),NG,NA,NA,Freight|Road,NA,NA,Freight|Road|Truck (7.5t),Freight|w/o bunkers
-Pass,Cycle,Cycle_tmp_subsector_L2,Cycle_tmp_subsector_L1,Cycle_tmp_vehicletype,Cycle_tmp_technology,Pass|non-LDV,NA,NA,Pass|Road|Non-Motorized|Cycling,Pass|Road|Non-Motorized,NA,Pass|w/o bunkers
-Pass,Domestic Aviation,Domestic Aviation_tmp_subsector_L2,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_vehicletype,Hydrogen,Pass|non-LDV,NA,Pass|Aviation|Domestic,NA,NA,NA,Pass|w/o bunkers
-Pass,Domestic Aviation,Domestic Aviation_tmp_subsector_L2,Domestic Aviation_tmp_subsector_L1,Domestic Aviation_tmp_vehicletype,Liquids,Pass|non-LDV,NA,Pass|Aviation|Domestic,NA,NA,NA,Pass|w/o bunkers
-Pass,HSR,HSR_tmp_subsector_L2,HSR_tmp_subsector_L1,HSR_tmp_vehicletype,Electric,Pass|non-LDV,NA,Pass|Rail|HSR,NA,NA,NA,Pass|w/o bunkers
-Pass,International Aviation,International Aviation_tmp_subsector_L2,International Aviation_tmp_subsector_L1,International Aviation_tmp_vehicletype,Hydrogen,Pass|non-LDV,NA,Pass|Aviation|International,NA,NA,NA,NA
-Pass,International Aviation,International Aviation_tmp_subsector_L2,International Aviation_tmp_subsector_L1,International Aviation_tmp_vehicletype,Liquids,Pass|non-LDV,NA,Pass|Aviation|International,NA,NA,NA,NA
-Pass,Passenger Rail,Passenger Rail_tmp_subsector_L2,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_vehicletype,Electric,Pass|non-LDV,NA,Pass|Rail|non-HSR,NA,NA,NA,Pass|w/o bunkers
-Pass,Passenger Rail,Passenger Rail_tmp_subsector_L2,Passenger Rail_tmp_subsector_L1,Passenger Rail_tmp_vehicletype,Liquids,Pass|non-LDV,NA,Pass|Rail|non-HSR,NA,NA,NA,Pass|w/o bunkers
-Pass,Walk,Walk_tmp_subsector_L2,Walk_tmp_subsector_L1,Walk_tmp_vehicletype,Walk_tmp_technology,Pass|non-LDV,NA,NA,Pass|Road|Non-Motorized|Walking,Pass|Road|Non-Motorized,NA,Pass|w/o bunkers
-Pass,trn_pass_road,Bus,Bus_tmp_subsector_L1,Bus_tmp_vehicletype,Electric,Pass|non-LDV,NA,Pass|Road|Bus,NA,NA,NA,Pass|w/o bunkers
-Pass,trn_pass_road,Bus,Bus_tmp_subsector_L1,Bus_tmp_vehicletype,FCEV,Pass|non-LDV,NA,Pass|Road|Bus,NA,NA,NA,Pass|w/o bunkers
-Pass,trn_pass_road,Bus,Bus_tmp_subsector_L1,Bus_tmp_vehicletype,Liquids,Pass|non-LDV,NA,Pass|Road|Bus,NA,NA,NA,Pass|w/o bunkers
-Pass,trn_pass_road,Bus,Bus_tmp_subsector_L1,Bus_tmp_vehicletype,NG,Pass|non-LDV,NA,Pass|Road|Bus,NA,NA,NA,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_2W,Moped,BEV,Pass|Road|LDV,NA,NA,NA,NA,Pass|Road|LDV|Two-Wheelers,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_2W,Moped,Liquids,Pass|Road|LDV,NA,NA,NA,NA,Pass|Road|LDV|Two-Wheelers,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_2W,Motorcycle (50-250cc),BEV,Pass|Road|LDV,NA,NA,NA,NA,Pass|Road|LDV|Two-Wheelers,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_2W,Motorcycle (50-250cc),Liquids,Pass|Road|LDV,NA,NA,NA,NA,Pass|Road|LDV|Two-Wheelers,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_2W,Motorcycle (>250cc),BEV,Pass|Road|LDV,NA,NA,NA,NA,Pass|Road|LDV|Two-Wheelers,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_2W,Motorcycle (>250cc),Liquids,Pass|Road|LDV,NA,NA,NA,NA,Pass|Road|LDV|Two-Wheelers,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Compact Car,BEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Medium,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Compact Car,FCEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Medium,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Compact Car,Hybrid Electric,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Medium,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Compact Car,Liquids,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Medium,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Compact Car,NG,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Medium,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Large Car,BEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Large,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Large Car,FCEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Large,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Large Car,Hybrid Electric,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Large,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Large Car,Liquids,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Large,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Large Car,NG,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Large,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Large Car and SUV,BEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|SUV,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Large Car and SUV,FCEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|SUV,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Large Car and SUV,Hybrid Electric,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|SUV,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Large Car and SUV,Liquids,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|SUV,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Large Car and SUV,NG,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|SUV,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Light Truck and SUV,BEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|SUV,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Light Truck and SUV,FCEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|SUV,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Light Truck and SUV,Hybrid Electric,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|SUV,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Light Truck and SUV,Liquids,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|SUV,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Light Truck and SUV,NG,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|SUV,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Midsize Car,BEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Large,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Midsize Car,FCEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Large,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Midsize Car,Hybrid Electric,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Large,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Midsize Car,Liquids,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Large,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Midsize Car,NG,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Large,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Mini Car,BEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Mini,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Mini Car,FCEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Mini,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Mini Car,Hybrid Electric,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Mini,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Mini Car,Liquids,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Mini,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Mini Car,NG,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Mini,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Subcompact Car,BEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Small,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Subcompact Car,FCEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Small,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Subcompact Car,Hybrid Electric,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Small,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Subcompact Car,Liquids,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Small,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Subcompact Car,NG,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Small,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Van,BEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Van,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Van,FCEV,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Van,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Van,Hybrid Electric,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Van,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Van,Liquids,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Van,Pass|w/o bunkers
-Pass,trn_pass_road,trn_pass_road_LDV,trn_pass_road_LDV_4W,Van,NG,Pass|Road|LDV,Pass|Road|LDV|4-Wheelers,NA,NA,NA,Pass|Road|LDV|Van,Pass|w/o bunkers
+sector;subsector_L3;subsector_L2;subsector_L1;vehicle_type;technology;aggr_mode;aggr_LDV;aggr_veh;nonmot;aggr_nonmot;det_veh;aggr_bunkers
+Freight;Domestic Ship;Domestic Ship_tmp_subsector_L2;Domestic Ship_tmp_subsector_L1;Domestic Ship_tmp_vehicletype;Liquids;NA;NA;Freight|Navigation;NA;NA;NA;Freight|w/o bunkers
+Freight;Freight Rail;Freight Rail_tmp_subsector_L2;Freight Rail_tmp_subsector_L1;Freight Rail_tmp_vehicletype;Electric;NA;NA;Freight|Rail;NA;NA;NA;Freight|w/o bunkers
+Freight;Freight Rail;Freight Rail_tmp_subsector_L2;Freight Rail_tmp_subsector_L1;Freight Rail_tmp_vehicletype;Liquids;NA;NA;Freight|Rail;NA;NA;NA;Freight|w/o bunkers
+Freight;International Ship;International Ship_tmp_subsector_L2;International Ship_tmp_subsector_L1;International Ship_tmp_vehicletype;Liquids;NA;NA;Freight|International Shipping;NA;NA;NA;NA
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (0-3.5t);Electric;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (0-3.5t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (0-3.5t);FCEV;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (0-3.5t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (0-3.5t);Liquids;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (0-3.5t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (0-3.5t);NG;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (0-3.5t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (18t);Electric;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (18t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (18t);FCEV;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (18t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (18t);Liquids;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (18t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (18t);NG;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (18t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (26t);Electric;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (26t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (26t);FCEV;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (26t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (26t);Liquids;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (26t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (26t);NG;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (26t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (40t);Electric;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (40t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (40t);FCEV;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (40t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (40t);Liquids;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (40t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (40t);NG;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (40t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (7.5t);Electric;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (7.5t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (7.5t);FCEV;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (7.5t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (7.5t);Liquids;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (7.5t);Freight|w/o bunkers
+Freight;trn_freight_road;trn_freight_road_tmp_subsector_L2;trn_freight_road_tmp_subsector_L1;Truck (7.5t);NG;NA;NA;Freight|Road;NA;NA;Freight|Road|Truck (7.5t);Freight|w/o bunkers
+Pass;Cycle;Cycle_tmp_subsector_L2;Cycle_tmp_subsector_L1;Cycle_tmp_vehicletype;Cycle_tmp_technology;Pass|non-LDV;NA;NA;Pass|Road|Non-Motorized|Cycling;Pass|Road|Non-Motorized;NA;Pass|w/o bunkers
+Pass;Domestic Aviation;Domestic Aviation_tmp_subsector_L2;Domestic Aviation_tmp_subsector_L1;Domestic Aviation_tmp_vehicletype;Hydrogen;Pass|non-LDV;NA;Pass|Aviation|Domestic;NA;NA;NA;Pass|w/o bunkers
+Pass;Domestic Aviation;Domestic Aviation_tmp_subsector_L2;Domestic Aviation_tmp_subsector_L1;Domestic Aviation_tmp_vehicletype;Liquids;Pass|non-LDV;NA;Pass|Aviation|Domestic;NA;NA;NA;Pass|w/o bunkers
+Pass;HSR;HSR_tmp_subsector_L2;HSR_tmp_subsector_L1;HSR_tmp_vehicletype;Electric;Pass|non-LDV;NA;Pass|Rail|HSR;NA;NA;NA;Pass|w/o bunkers
+Pass;International Aviation;International Aviation_tmp_subsector_L2;International Aviation_tmp_subsector_L1;International Aviation_tmp_vehicletype;Hydrogen;Pass|non-LDV;NA;Pass|Aviation|International;NA;NA;NA;NA
+Pass;International Aviation;International Aviation_tmp_subsector_L2;International Aviation_tmp_subsector_L1;International Aviation_tmp_vehicletype;Liquids;Pass|non-LDV;NA;Pass|Aviation|International;NA;NA;NA;NA
+Pass;Passenger Rail;Passenger Rail_tmp_subsector_L2;Passenger Rail_tmp_subsector_L1;Passenger Rail_tmp_vehicletype;Electric;Pass|non-LDV;NA;Pass|Rail|non-HSR;NA;NA;NA;Pass|w/o bunkers
+Pass;Passenger Rail;Passenger Rail_tmp_subsector_L2;Passenger Rail_tmp_subsector_L1;Passenger Rail_tmp_vehicletype;Liquids;Pass|non-LDV;NA;Pass|Rail|non-HSR;NA;NA;NA;Pass|w/o bunkers
+Pass;Walk;Walk_tmp_subsector_L2;Walk_tmp_subsector_L1;Walk_tmp_vehicletype;Walk_tmp_technology;Pass|non-LDV;NA;NA;Pass|Road|Non-Motorized|Walking;Pass|Road|Non-Motorized;NA;Pass|w/o bunkers
+Pass;trn_pass_road;Bus;Bus_tmp_subsector_L1;Bus_tmp_vehicletype;Electric;Pass|non-LDV;NA;Pass|Road|Bus;NA;NA;NA;Pass|w/o bunkers
+Pass;trn_pass_road;Bus;Bus_tmp_subsector_L1;Bus_tmp_vehicletype;FCEV;Pass|non-LDV;NA;Pass|Road|Bus;NA;NA;NA;Pass|w/o bunkers
+Pass;trn_pass_road;Bus;Bus_tmp_subsector_L1;Bus_tmp_vehicletype;Liquids;Pass|non-LDV;NA;Pass|Road|Bus;NA;NA;NA;Pass|w/o bunkers
+Pass;trn_pass_road;Bus;Bus_tmp_subsector_L1;Bus_tmp_vehicletype;NG;Pass|non-LDV;NA;Pass|Road|Bus;NA;NA;NA;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_2W;Moped;BEV;Pass|Road|LDV;NA;NA;NA;NA;Pass|Road|LDV|Two Wheelers;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_2W;Moped;Liquids;Pass|Road|LDV;NA;NA;NA;NA;Pass|Road|LDV|Two Wheelers;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_2W;Motorcycle (50-250cc);BEV;Pass|Road|LDV;NA;NA;NA;NA;Pass|Road|LDV|Two Wheelers;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_2W;Motorcycle (50-250cc);Liquids;Pass|Road|LDV;NA;NA;NA;NA;Pass|Road|LDV|Two Wheelers;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_2W;Motorcycle (>250cc);BEV;Pass|Road|LDV;NA;NA;NA;NA;Pass|Road|LDV|Two Wheelers;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_2W;Motorcycle (>250cc);Liquids;Pass|Road|LDV;NA;NA;NA;NA;Pass|Road|LDV|Two Wheelers;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Compact Car;BEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Medium;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Compact Car;FCEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Medium;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Compact Car;Hybrid Electric;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Medium;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Compact Car;Liquids;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Medium;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Compact Car;NG;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Medium;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Large Car;BEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Large;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Large Car;FCEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Large;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Large Car;Hybrid Electric;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Large;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Large Car;Liquids;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Large;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Large Car;NG;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Large;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Large Car and SUV;BEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|SUV;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Large Car and SUV;FCEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|SUV;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Large Car and SUV;Hybrid Electric;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|SUV;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Large Car and SUV;Liquids;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|SUV;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Large Car and SUV;NG;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|SUV;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Light Truck and SUV;BEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|SUV;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Light Truck and SUV;FCEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|SUV;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Light Truck and SUV;Hybrid Electric;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|SUV;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Light Truck and SUV;Liquids;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|SUV;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Light Truck and SUV;NG;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|SUV;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Midsize Car;BEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Large;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Midsize Car;FCEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Large;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Midsize Car;Hybrid Electric;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Large;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Midsize Car;Liquids;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Large;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Midsize Car;NG;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Large;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Mini Car;BEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Mini;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Mini Car;FCEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Mini;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Mini Car;Hybrid Electric;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Mini;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Mini Car;Liquids;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Mini;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Mini Car;NG;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Mini;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Subcompact Car;BEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Small;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Subcompact Car;FCEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Small;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Subcompact Car;Hybrid Electric;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Small;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Subcompact Car;Liquids;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Small;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Subcompact Car;NG;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Small;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Van;BEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Van;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Van;FCEV;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Van;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Van;Hybrid Electric;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Van;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Van;Liquids;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Van;Pass|w/o bunkers
+Pass;trn_pass_road;trn_pass_road_LDV;trn_pass_road_LDV_4W;Van;NG;Pass|Road|LDV;Pass|Road|LDV|Four Wheelers;NA;NA;NA;Pass|Road|LDV|Van;Pass|w/o bunkers

--- a/inst/rmd/compareScenarios_Transport/csEDGET_01_energy_demand.Rmd
+++ b/inst/rmd/compareScenarios_Transport/csEDGET_01_energy_demand.Rmd
@@ -8,11 +8,12 @@
 tot <- "FE|Transport"
 items <- c(
   "FE|Transport|Electricity",
+  "FE|Transport|Hydrogen",
   "FE|Transport|Gases",
-  "FE|Transport|Liquids",
-  "FE|Transport|Hydrogen")
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+  "FE|Transport|Liquids"
+  )
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot)
 walk(items, showLinePlots, data=data)
 ```
@@ -22,11 +23,12 @@ walk(items, showLinePlots, data=data)
 tot <- "FE|Transport|w/o bunkers"
 items <- c(
   "FE|Transport|w/o bunkers|Electricity",
+  "FE|Transport|w/o bunkers|Hydrogen",
   "FE|Transport|w/o bunkers|Gases",
-  "FE|Transport|w/o bunkers|Liquids",
-  "FE|Transport|w/o bunkers|Hydrogen")
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+  "FE|Transport|w/o bunkers|Liquids"
+  )
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot)
 walk(items, showLinePlots, data=data)
 ```
@@ -36,11 +38,12 @@ walk(items, showLinePlots, data=data)
 tot <- "FE|Transport|Pass"
 items <- c(
   "FE|Transport|Pass|Electricity",
+  "FE|Transport|Pass|Hydrogen",
   "FE|Transport|Pass|Gases",
-  "FE|Transport|Pass|Liquids",
-  "FE|Transport|Pass|Hydrogen")
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+  "FE|Transport|Pass|Liquids"
+  )
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot)
 walk(items, showLinePlots, data=data)
 ```
@@ -50,37 +53,39 @@ walk(items, showLinePlots, data=data)
 tot <- "FE|Transport|Pass|w/o bunkers"
 items <- c(
   "FE|Transport|Pass|w/o bunkers|Electricity",
+  "FE|Transport|Pass|w/o bunkers|Hydrogen",
   "FE|Transport|Pass|w/o bunkers|Gases",
-  "FE|Transport|Pass|w/o bunkers|Liquids",
-  "FE|Transport|Pass|w/o bunkers|Hydrogen")
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+  "FE|Transport|Pass|w/o bunkers|Liquids"
+  )
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot)
 walk(items, showLinePlots, data=data)
 ```
 
-### Passenger LDV 4-Wheelers
+### Passenger LDV Four Wheelers
 ```{r}
-tot <- "FE|Transport|Pass|Road|LDV|4-Wheelers"
+tot <- "FE|Transport|Pass|Road|LDV|Four Wheelers"
 items <- c(
-  "FE|Transport|Pass|Road|LDV|4-Wheelers|Electricity",
-  "FE|Transport|Pass|Road|LDV|4-Wheelers|Gases",
-  "FE|Transport|Pass|Road|LDV|4-Wheelers|Liquids",
-  "FE|Transport|Pass|Road|LDV|4-Wheelers|Hydrogen")
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+  "FE|Transport|Pass|Road|LDV|Four Wheelers|Electricity",
+  "FE|Transport|Pass|Road|LDV|Four Wheelers|Hydrogen",
+  "FE|Transport|Pass|Road|LDV|Four Wheelers|Gases",
+  "FE|Transport|Pass|Road|LDV|Four Wheelers|Liquids"
+  )
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot)
 walk(items, showLinePlots, data=data)
 ```
 
-### Passenger LDV 2-Wheelers
+### Passenger LDV Two Wheelers
 ```{r}
-tot <- "FE|Transport|Pass|Road|LDV|Two-Wheelers"
+tot <- "FE|Transport|Pass|Road|LDV|Two Wheelers"
 items <- c(
-  "FE|Transport|Pass|Road|LDV|Two-Wheelers|Electricity",
-  "FE|Transport|Pass|Road|LDV|Two-Wheelers|Liquids")
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+  "FE|Transport|Pass|Road|LDV|Two Wheelers|Electricity",
+  "FE|Transport|Pass|Road|LDV|Two Wheelers|Liquids")
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot)
 walk(items, showLinePlots, data=data)
 ```
@@ -90,11 +95,12 @@ walk(items, showLinePlots, data=data)
 tot <- "FE|Transport|Pass|Road|Bus"
 items <- c(
   "FE|Transport|Pass|Road|Bus|Electricity",
+  "FE|Transport|Pass|Road|Bus|Hydrogen",
   "FE|Transport|Pass|Road|Bus|Gases",
-  "FE|Transport|Pass|Road|Bus|Liquids",
-  "FE|Transport|Pass|Road|Bus|Hydrogen")
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+  "FE|Transport|Pass|Road|Bus|Liquids"
+  )
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot)
 walk(items, showLinePlots, data=data)
 ```
@@ -105,8 +111,8 @@ tot <- "FE|Transport|Pass|Rail|non-HSR"
 items <- c(
   "FE|Transport|Pass|Rail|non-HSR|Electricity",
   "FE|Transport|Pass|Rail|non-HSR|Liquids")
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot)
 walk(items, showLinePlots, data=data)
 ```
@@ -116,11 +122,12 @@ walk(items, showLinePlots, data=data)
 tot <- "FE|Transport|Freight"
 items <- c(
   "FE|Transport|Freight|Electricity",
+  "FE|Transport|Freight|Hydrogen",
   "FE|Transport|Freight|Gases",
-  "FE|Transport|Freight|Liquids",
-  "FE|Transport|Freight|Hydrogen")
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+  "FE|Transport|Freight|Liquids"
+  )
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot)
 walk(items, showLinePlots, data=data)
 ```
@@ -130,11 +137,12 @@ walk(items, showLinePlots, data=data)
 tot <- "FE|Transport|Freight|w/o bunkers"
 items <- c(
   "FE|Transport|Freight|w/o bunkers|Electricity",
+  "FE|Transport|Freight|w/o bunkers|Hydrogen",
   "FE|Transport|Freight|w/o bunkers|Gases",
-  "FE|Transport|Freight|w/o bunkers|Liquids",
-  "FE|Transport|Freight|w/o bunkers|Hydrogen")
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+  "FE|Transport|Freight|w/o bunkers|Liquids"
+  )
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot)
 walk(items, showLinePlots, data=data)
 ```
@@ -144,11 +152,12 @@ walk(items, showLinePlots, data=data)
 tot <- "FE|Transport|Freight|Road"
 items <- c(
   "FE|Transport|Freight|Road|Electricity",
+  "FE|Transport|Freight|Road|Hydrogen",
   "FE|Transport|Freight|Road|Gases",
-  "FE|Transport|Freight|Road|Liquids",
-  "FE|Transport|Freight|Road|Hydrogen")
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+  "FE|Transport|Freight|Road|Liquids"
+  )
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot)
 walk(items, showLinePlots, data=data)
 ```
@@ -159,8 +168,8 @@ tot <- "FE|Transport|Freight|Rail"
 items <- c(
   "FE|Transport|Freight|Rail|Electricity",
   "FE|Transport|Freight|Rail|Liquids")
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot)
 walk(items, showLinePlots, data=data)
 ```
@@ -186,15 +195,15 @@ tot_wobunk <- "FE|Transport|Pass|w/o bunkers"
 items <- c(
     "FE|Transport|Pass|Aviation|International",
     "FE|Transport|Pass|Aviation|Domestic",
-    "FE|Transport|Pass|Rail|non-HSR",
     "FE|Transport|Pass|Rail|HSR",
+    "FE|Transport|Pass|Rail|non-HSR",
     "FE|Transport|Pass|Road|Bus",
     "FE|Transport|Pass|Road|LDV"
   )
-showAreaAndBarPlots(data, items, tot_wbunk)
-showAreaAndBarPlots(data, items[2:6], tot_wobunk)
-showAreaAndBarPlots(data, items, tot_wbunk, fill=TRUE)
-showAreaAndBarPlots(data, items[2:6], tot_wobunk, fill=TRUE)
+showAreaAndBarPlots(data, items, tot_wbunk, orderVars = "user")
+showAreaAndBarPlots(data, items[2:6], tot_wobunk, orderVars = "user")
+showAreaAndBarPlots(data, items, tot_wbunk, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items[2:6], tot_wobunk, fill=TRUE, orderVars = "user")
 ```
 
 ### Freight
@@ -203,12 +212,12 @@ tot_wbunk <- "FE|Transport|Freight"
 tot_wobunk <- "FE|Transport|Freight|w/o bunkers"
 items <- c(
       "FE|Transport|Freight|International Shipping",
-      "FE|Transport|Freight|Road",
+      "FE|Transport|Freight|Navigation",
       "FE|Transport|Freight|Rail",
-      "FE|Transport|Freight|Navigation"
+      "FE|Transport|Freight|Road"
   )
-showAreaAndBarPlots(data, items, tot_wbunk)
-showAreaAndBarPlots(data, items[2:4], tot_wobunk)
-showAreaAndBarPlots(data, items, tot_wbunk, fill=TRUE)
-showAreaAndBarPlots(data, items[2:4], tot_wobunk, fill=TRUE)
+showAreaAndBarPlots(data, items, tot_wbunk, orderVars = "user")
+showAreaAndBarPlots(data, items[2:4], tot_wobunk, orderVars = "user")
+showAreaAndBarPlots(data, items, tot_wbunk, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items[2:4], tot_wobunk, fill=TRUE, orderVars = "user")
 ```

--- a/inst/rmd/compareScenarios_Transport/csEDGET_02_energy_services.Rmd
+++ b/inst/rmd/compareScenarios_Transport/csEDGET_02_energy_services.Rmd
@@ -6,20 +6,20 @@ tot_wobunk <- "ES|Transport|Pass|w/o bunkers"
 items <- c(
     "ES|Transport|Pass|Aviation|International",
     "ES|Transport|Pass|Aviation|Domestic",
-    "ES|Transport|Pass|Rail|non-HSR",
     "ES|Transport|Pass|Rail|HSR",
+    "ES|Transport|Pass|Rail|non-HSR",
     "ES|Transport|Pass|Road|Bus",
-    "ES|Transport|Pass|Road|LDV|4-Wheelers",
-    "ES|Transport|Pass|Road|LDV|Two-Wheelers",
+    "ES|Transport|Pass|Road|LDV|Four Wheelers",
+    "ES|Transport|Pass|Road|LDV|Two Wheelers",
     "ES|Transport|Pass|Road|Non-Motorized|Walking",
     "ES|Transport|Pass|Road|Non-Motorized|Cycling"
   )
-showAreaAndBarPlots(data, items, tot_wbunk)
-showAreaAndBarPlots(data, items[2:8], tot_wobunk)
-showAreaAndBarPlots(data, items, tot_wbunk, fill=TRUE)
-showAreaAndBarPlots(data, items[2:8], tot_wobunk, fill=TRUE)
+showAreaAndBarPlots(data, items, tot_wbunk,  orderVars = "user")
+showAreaAndBarPlots(data, items[2:9], tot_wobunk, orderVars = "user")
+showAreaAndBarPlots(data, items, tot_wbunk, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items[2:9], tot_wobunk, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot_wbunk)
-walk(items, showLinePlots, data=data)
+walk(items, showLinePlots, data = data)
 ```
 
 ## Passenger per Capita
@@ -29,71 +29,60 @@ items <- c(
     "ES|Transport|Pass|w/o bunkers pCap",
     "ES|Transport|Pass|Aviation|International pCap",
     "ES|Transport|Pass|Aviation|Domestic pCap",
-    "ES|Transport|Pass|Rail|non-HSR pCap",
     "ES|Transport|Pass|Rail|HSR pCap",
+    "ES|Transport|Pass|Rail|non-HSR pCap",
     "ES|Transport|Pass|Road|Bus pCap",
-    "ES|Transport|Pass|Road|LDV|4-Wheelers pCap",
-    "ES|Transport|Pass|Road|LDV|Two-Wheelers pCap",
+    "ES|Transport|Pass|Road|LDV|Four Wheelers pCap",
+    "ES|Transport|Pass|Road|LDV|Two Wheelers pCap",
     "ES|Transport|Pass|Road|Non-Motorized|Walking pCap",
     "ES|Transport|Pass|Road|Non-Motorized|Cycling pCap")
 showMultiLinePlots(data, items)    
 showMultiLinePlotsByVariable(data, items, "GDP|PPP pCap")
 ```
 
-## Passenger per Capita with original ETP values
-```{r}
-# items <- c(
-#     "ES|Transport|Pass|Aviation pCap",
-#     "ES|Transport|Pass|Rail pCap",
-#     "ES|Transport|Pass|Road|Bus pCap",
-#     "ES|Transport|Pass|Road|LDV pCap")
-# showMultiLinePlots(data, items)    
-# showMultiLinePlotsByVariable_orig_ETP(data, items, "GDP|PPP pCap")
-```
-
-## LDV 4-Wheelers 
+## LDV Four Wheelers 
 
 ### By vehicle size
 ```{r}
-tot <- "ES|Transport|Pass|Road|LDV|4-Wheelers"
+tot <- "ES|Transport|Pass|Road|LDV|Four Wheelers"
 items <- c(
+       "ES|Transport|Pass|Road|LDV|Van",
+       "ES|Transport|Pass|Road|LDV|SUV",
        "ES|Transport|Pass|Road|LDV|Large",
        "ES|Transport|Pass|Road|LDV|Medium",
-       "ES|Transport|Pass|Road|LDV|SUV",
-       "ES|Transport|Pass|Road|LDV|Mini",
        "ES|Transport|Pass|Road|LDV|Small",
-       "ES|Transport|Pass|Road|LDV|Van"
+       "ES|Transport|Pass|Road|LDV|Mini"
   )
 
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE,  orderVars = "user")
 ```
 
 ### By technology
 ```{r}
-tot <- "ES|Transport|Pass|Road|LDV|4-Wheelers"
+tot <- "ES|Transport|Pass|Road|LDV|Four Wheelers"
 items <- c(
-       "ES|Transport|Pass|Road|LDV|4-Wheelers|BEV",
-       "ES|Transport|Pass|Road|LDV|4-Wheelers|FCEV",
-       "ES|Transport|Pass|Road|LDV|4-Wheelers|Hybrid Electric",
-       "ES|Transport|Pass|Road|LDV|4-Wheelers|Gases",
-       "ES|Transport|Pass|Road|LDV|4-Wheelers|Liquids"
+       "ES|Transport|Pass|Road|LDV|Four Wheelers|BEV",
+       "ES|Transport|Pass|Road|LDV|Four Wheelers|FCEV",
+       "ES|Transport|Pass|Road|LDV|Four Wheelers|Hybrid Electric",
+       "ES|Transport|Pass|Road|LDV|Four Wheelers|Gases",
+       "ES|Transport|Pass|Road|LDV|Four Wheelers|Liquids"
   )
 
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 ```
 
 ## LDV 2-Wheelers by technology
 ```{r}
-tot <- "ES|Transport|Pass|Road|LDV|Two-Wheelers"
+tot <- "ES|Transport|Pass|Road|LDV|Two Wheelers"
 items <- c(
-     "ES|Transport|Pass|Road|LDV|Two-Wheelers|BEV",
-     "ES|Transport|Pass|Road|LDV|Two-Wheelers|Liquids" 
+     "ES|Transport|Pass|Road|LDV|Two Wheelers|BEV",
+     "ES|Transport|Pass|Road|LDV|Two Wheelers|Liquids" 
   )
 
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 ```
 
 ## Busses by technology
@@ -106,8 +95,8 @@ items <- c(
        "ES|Transport|Pass|Road|Bus|Liquids" 
   )
 
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 ```
 
 ## Freight
@@ -116,14 +105,14 @@ tot_wbunk <- "ES|Transport|Freight"
 tot_wobunk <- "ES|Transport|Freight|w/o bunkers"
 items <- c(
       "ES|Transport|Freight|International Shipping",
-      "ES|Transport|Freight|Road",
+      "ES|Transport|Freight|Navigation",
       "ES|Transport|Freight|Rail",
-      "ES|Transport|Freight|Navigation"
+      "ES|Transport|Freight|Road"
   )
-showAreaAndBarPlots(data, items, tot_wbunk)
-showAreaAndBarPlots(data, items[2:4], tot_wobunk)
-showAreaAndBarPlots(data, items, tot_wbunk, fill=TRUE)
-showAreaAndBarPlots(data, items[2:4], tot_wobunk, fill=TRUE)
+showAreaAndBarPlots(data, items, tot_wbunk, orderVars = "user")
+showAreaAndBarPlots(data, items[2:4], tot_wobunk, orderVars = "user")
+showAreaAndBarPlots(data, items, tot_wbunk, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items[2:4], tot_wobunk, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot_wbunk)
 walk(items, showLinePlots, data=data)
 ```
@@ -134,9 +123,9 @@ walk(items, showLinePlots, data=data)
 items <- c(
       "ES|Transport|Freight|w/o bunkers pCap",
       "ES|Transport|Freight|International Shipping pCap",
-      "ES|Transport|Freight|Road pCap",
+      "ES|Transport|Freight|Navigation pCap",
       "ES|Transport|Freight|Rail pCap",
-      "ES|Transport|Freight|Navigation pCap"
+      "ES|Transport|Freight|Road pCap"
     )
 showMultiLinePlots(data, items)    
 showMultiLinePlotsByVariable(data, items, "GDP|PPP pCap")
@@ -148,15 +137,15 @@ showMultiLinePlotsByVariable(data, items, "GDP|PPP pCap")
 ```{r}
 tot <- "ES|Transport|Freight|Road"
 items <- c(
-       "ES|Transport|Freight|Road|Truck (0-3.5t)",
-       "ES|Transport|Freight|Road|Truck (7.5t)",
-       "ES|Transport|Freight|Road|Truck (18t)",
+       "ES|Transport|Freight|Road|Truck (40t)",
        "ES|Transport|Freight|Road|Truck (26t)",
-       "ES|Transport|Freight|Road|Truck (40t)"
+       "ES|Transport|Freight|Road|Truck (18t)",
+       "ES|Transport|Freight|Road|Truck (7.5t)",
+       "ES|Transport|Freight|Road|Truck (0-3.5t)"
   )
 
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 ```
 
 ### By technology
@@ -169,6 +158,6 @@ items <- c(
        "ES|Transport|Freight|Road|Liquids"
   )
 
-showAreaAndBarPlots(data, items, tot)
-showAreaAndBarPlots(data, items, tot, fill=TRUE)
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 ```

--- a/inst/rmd/compareScenarios_Transport/csEDGET_02_energy_services.Rmd
+++ b/inst/rmd/compareScenarios_Transport/csEDGET_02_energy_services.Rmd
@@ -9,7 +9,8 @@ items <- c(
     "ES|Transport|Pass|Rail|non-HSR",
     "ES|Transport|Pass|Rail|HSR",
     "ES|Transport|Pass|Road|Bus",
-    "ES|Transport|Pass|Road|LDV",
+    "ES|Transport|Pass|Road|LDV|4-Wheelers",
+    "ES|Transport|Pass|Road|LDV|Two-Wheelers",
     "ES|Transport|Pass|Road|Non-Motorized|Walking",
     "ES|Transport|Pass|Road|Non-Motorized|Cycling"
   )
@@ -31,7 +32,8 @@ items <- c(
     "ES|Transport|Pass|Rail|non-HSR pCap",
     "ES|Transport|Pass|Rail|HSR pCap",
     "ES|Transport|Pass|Road|Bus pCap",
-    "ES|Transport|Pass|Road|LDV pCap",
+    "ES|Transport|Pass|Road|LDV|4-Wheelers pCap",
+    "ES|Transport|Pass|Road|LDV|Two-Wheelers pCap",
     "ES|Transport|Pass|Road|Non-Motorized|Walking pCap",
     "ES|Transport|Pass|Road|Non-Motorized|Cycling pCap")
 showMultiLinePlots(data, items)    

--- a/inst/rmd/compareScenarios_Transport/csEDGET_04_costs_and_shareweight_trends.Rmd
+++ b/inst/rmd/compareScenarios_Transport/csEDGET_04_costs_and_shareweight_trends.Rmd
@@ -90,6 +90,7 @@ for (reg0 in CostReg) {
 
 
 ```
+
 ## LDV non fuel prices for different technologies and vehicle sizes
 ```{r LDV non fuel prices for different technologies and vehicle sizes}
 
@@ -146,6 +147,7 @@ for (reg0 in CostReg) {
 
   p <- lineplot(varname = paste0("Shareweight trend S3 ", reg0), data = plotdata)
   print(p)
+  
   cat("\n\n")
   plotdata <- data[grepl("Shareweight\\|S2\\|(Bus|trn_pass_road_LDV)",variable) & region == reg0]
   plotdata <- plotdata[, variable := gsub("Shareweight\\|S2\\|", "",variable)]
@@ -153,6 +155,7 @@ for (reg0 in CostReg) {
   p <- lineplot(varname = paste0("Shareweight trend S2 ", reg0), data = plotdata)
   print(p)
   cat("\n\n")
+  
   plotdata <- data[grepl("Shareweight\\|S1\\|(trn_pass_road_LDV_2W|trn_pass_road_LDV_4W)",variable) & region == reg0]
   plotdata <- plotdata[, variable := gsub("Shareweight\\|S1\\|", "", variable)]
   

--- a/inst/rmd/compareScenarios_Transport/csEDGET_main.Rmd
+++ b/inst/rmd/compareScenarios_Transport/csEDGET_main.Rmd
@@ -73,10 +73,10 @@ library(tidyverse)
 library(kableExtra)
 library(quitte)
 library(devtools)
-library(mip)
 library(edgeTrpLib)
 library(data.table)
 library(mrremind)
+library(mip)
 setConfig(forcecache = T) 
 ```
 
@@ -196,8 +196,10 @@ pCapVariables <- tribble(
   "ES|Transport|Freight|International Shipping", "tkm/yr", 1e9,
   "ES|Transport|Freight|Road", "tkm/yr", 1e9,
   "ES|Transport|Freight|Navigation", "tkm/yr", 1e9,
-  "ES|Transport|Freight|Rail pCap", "tkm/yr", 1e9,
+  "ES|Transport|Freight|Rail", "tkm/yr", 1e9,
   "ES|Transport|Pass|Road|LDV", "km/yr", 1e9,
+  "ES|Transport|Pass|Road|LDV|Four Wheelers", "km/yr", 1e9,
+  "ES|Transport|Pass|Road|LDV|Two Wheelers", "km/yr", 1e9,
   "ES|Transport|Pass|non-LDV", "km/yr", 1e9,
   "ES|Transport|Pass|Road|LDV|BEV", "km/yr", 1e9,
   "ES|Transport|Pass|Road|LDV|FCEV", "km/yr", 1e9,


### PR DESCRIPTION
**Add a differentiation between LDV Four Wheelers and LDV 2 Wheelers:**
- Change Plots
- Rename LDV 4-Wheelers to LDV Four Wheelers as well as LDV Two-Wheelers to LDV Two Wheelers for mip color compatibitility in the reporting and in the plots

**Include fixed order of variables in the plots**

