### PR TITLE
Extend the EDGE-T outputs to obtain reasonable values for BEVs and PHEVs

### DIFF
--- a/R/calculate_logit_inconv_endog.R
+++ b/R/calculate_logit_inconv_endog.R
@@ -73,7 +73,7 @@ calculate_logit_inconv_endog = function(prices,
     MJ_km <- merge(df, mj_km_data, by=intersect(names(df),names(mj_km_data)),all = FALSE)
 
     MJ_km <- MJ_km[, .(MJ_km = sum(share * MJ_km)),
-                   by = c("region", "year", "technology", group_value)]
+                   by = c("region", "year", group_value)]
 
     ## get rid of the ( misleading afterwards) columns
     df_shares <- copy(df)
@@ -400,7 +400,7 @@ calculate_logit_inconv_endog = function(prices,
     ## merge energy intensity
     MJ_km <- merge(df, mj_km_data, by=intersect(names(df),names(mj_km_data)),all = FALSE)
     MJ_km <- MJ_km[, .(MJ_km = sum(share * MJ_km)),
-                   by = c("region", "year", "technology", group_value)]
+                   by = c("region", "year", group_value)]
 
     ## save complete dt at this level
     df_shares <- copy(df)

--- a/R/shares_intensities_and_demand.R
+++ b/R/shares_intensities_and_demand.R
@@ -2,7 +2,6 @@
 #'
 #' @param logit_shares logit tree level shares
 #' @param MJ_km_base logit tree level intensities
-#' @param EDGE2CESmap map top level EDGE-T categories to CES tree nodes
 #' @param REMINDyears range of REMIND time steps
 #' @param scenario REMIND GDP scenario
 #' @param demand_input full REMIND CES level ES demand, optional. If not given, logit level demand output is normalized.
@@ -12,7 +11,6 @@
 
 shares_intensity_and_demand <- function(logit_shares,
                                         MJ_km_base,
-                                        EDGE2CESmap,
                                         REMINDyears,
                                         scenario,
                                         demand_input=NULL){

--- a/R/shares_intensities_and_demand.R
+++ b/R/shares_intensities_and_demand.R
@@ -74,7 +74,7 @@ shares_intensity_and_demand <- function(logit_shares,
     ## plug in hybrids need to be redistributed on liquids and BEVs (on fuel consumtpion)
     demandFPIH = demandF[technology == "Hybrid Electric"]
     demandFPIH[, c("demand_EJel", "demand_EJliq") := list(0.4*demand_EJ, 0.6*demand_EJ)]
-    demandFPIH[, c("MJ_kmel", "MJ_kmliq") := list((demand_EJel+demand_EJliq)*MJ_km/demand_EJel, (demand_EJel+demand_EJliq)*MJ_km/demand_EJliq)]
+    demandFPIH[, c("MJ_kmel", "MJ_kmliq") := list(0.4*MJ_km, 0.6*MJ_km)]
     demandFPIH[, c("demand_Fel", "demand_Fliq") := list(demand_EJel/(1e6*MJ_kmel*1e-12), demand_EJel/(1e6*MJ_kmliq*1e-12))]
     demandFPIH[, c("demand_EJ", "demand_F", "technology", "sector_fuel", "MJ_kmel", "MJ_kmliq") := NULL]
     demandFPIH = melt(demandFPIH, id.vars = c("region", "sector", "year", "subsector_L3", "subsector_L2", "subsector_L1", "vehicle_type", "MJ_km"),

--- a/inst/extdata/mapping_EDGECES.csv
+++ b/inst/extdata/mapping_EDGECES.csv
@@ -1,0 +1,15 @@
+sector,fuel,CES_node
+trn_pass,Electric,feelt_p_sm
+trn_pass,Liquids,fepet_p_sm
+trn_pass,NG,fegat_p_sm
+trn_pass,Hydrogen,feh2t_p_sm
+trn_freight,Electric,feelt_f_sm
+trn_freight,Liquids,fedie_f_sm
+trn_freight,NG,fegat_f_sm
+trn_freight,Hydrogen,feh2t_f_sm
+trn_aviation_intl,Electric,feelt_p_lo
+trn_aviation_intl,Liquids,fedie_p_lo
+trn_aviation_intl,Hydrogen,feh2t_p_lo
+trn_shipping_intl,Electric,feelt_f_lo
+trn_shipping_intl,Liquids,fedie_f_lo
+trn_shipping_intl,Hydrogen,feh2t_f_lo


### PR DESCRIPTION
Add an additional column `fuel` to `demandF_plot_EJ` and `demandF_plot_pkm` which contains the actual fuel used. This allows to correctly report liquid and electricity demand for PHEVs.

- as a side effect, a bug in the intensity calculation for PHEVs has been fixed.
- a simplified CES-EDGE-T mapping is introduced that only contains the relevant columns.

**Note**: A similar change should occur for `calculate_capCosts.R`, where PHEVs are just filtered out. This would require to calculate *average* fuel costs for the liquids + electricity mix that the PHEV consumes.