### PR TITLE
Bugfixes to version 1.6.0

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3060000'
+ValidationKey: '3079608'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "edgeTrpLib: Helper functions for EDGE transport calculations",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "<p>This package is highly specialized and created solely to not duplicate helper functions.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: edgeTrpLib
 Title: Helper functions for EDGE transport calculations
-Version: 1.6.0
+Version: 1.6.1
 Authors@R: c(
     person("Alois", "Dirnaichner", email = "dirnaichner@pik-potsdam.de", role = c("aut", "cre")),
     person("Marianna", "Rottoli", email = "rottoli@pik-potsdam.de", role = "aut"))		    
@@ -23,6 +23,6 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.2
-Date: 2022-05-13
+Date: 2022-05-16
 Suggests: 
     covr

--- a/R/calculate_logit_inconv_endog.R
+++ b/R/calculate_logit_inconv_endog.R
@@ -73,7 +73,7 @@ calculate_logit_inconv_endog = function(prices,
     MJ_km <- merge(df, mj_km_data, by=intersect(names(df),names(mj_km_data)),all = FALSE)
 
     MJ_km <- MJ_km[, .(MJ_km = sum(share * MJ_km)),
-                   by = c("region", "year", group_value)]
+                   by = c("region", "year", "technology", group_value)]
 
     ## get rid of the ( misleading afterwards) columns
     df_shares <- copy(df)
@@ -400,7 +400,7 @@ calculate_logit_inconv_endog = function(prices,
     ## merge energy intensity
     MJ_km <- merge(df, mj_km_data, by=intersect(names(df),names(mj_km_data)),all = FALSE)
     MJ_km <- MJ_km[, .(MJ_km = sum(share * MJ_km)),
-                   by = c("region", "year", group_value)]
+                   by = c("region", "year", "technology", group_value)]
 
     ## save complete dt at this level
     df_shares <- copy(df)

--- a/R/shares_intensities_and_demand.R
+++ b/R/shares_intensities_and_demand.R
@@ -97,8 +97,8 @@ Hybrid Electric,Liquids")
 
     EDGE2CESmap <- fread(system.file("extdata", "mapping_EDGECES.csv", package = "edgeTrpLib"))
     ## first I need to merge with a mapping that represents how the entries match to the CES
-    demandF = merge(demandF, EDGE2CESmap, all=TRUE,
-                  by = c("sector", "fuel"))
+    demandF <- merge(demandF, EDGE2CESmap, all=TRUE,
+                    by = c("sector", "subsector_L2", "fuel"))
 
     ## calculate both shares and average energy intensity
     demandF = demandF[,.(region, year, Value_demand = demand_EJ, demand_F, CES_node, sector)]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Helper functions for EDGE transport calculations
 
-R package **edgeTrpLib**, version **1.6.0**
+R package **edgeTrpLib**, version **1.6.1**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/edgeTrpLib)](https://cran.r-project.org/package=edgeTrpLib)  [![R build status](https://github.com/johannah-pik/edgeTrpLib/workflows/check/badge.svg)](https://github.com/johannah-pik/edgeTrpLib/actions) [![codecov](https://codecov.io/gh/johannah-pik/edgeTrpLib/branch/master/graph/badge.svg)](https://app.codecov.io/gh/johannah-pik/edgeTrpLib) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTrpLib)](https://pik-piam.r-universe.dev/ui#builds)
+[![CRAN status](https://www.r-pkg.org/badges/version/edgeTrpLib)](https://cran.r-project.org/package=edgeTrpLib)  [![R build status](https://gitlab.pik-potsdam.de/REMIND/edgetrplib/workflows/check/badge.svg)](https://gitlab.pik-potsdam.de/REMIND/edgetrplib/actions) [![codecov](https://codecov.io/gh/REMIND/edgetrplib/branch/master/graph/badge.svg)](https://app.codecov.io/gh/REMIND/edgetrplib) [![r-universe](https://pik-piam.r-universe.dev/badges/edgeTrpLib)](https://pik-piam.r-universe.dev/ui#builds)
 
 ## Purpose and Functionality
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Alois Dirnaichner <dirnaichner@pi
 
 To cite package **edgeTrpLib** in publications use:
 
-Dirnaichner A, Rottoli M (2022). _edgeTrpLib: Helper functions for EDGE transport calculations_. R package version 1.6.0.
+Dirnaichner A, Rottoli M (2022). _edgeTrpLib: Helper functions for EDGE transport calculations_. R package version 1.6.1.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,6 +47,6 @@ A BibTeX entry for LaTeX users is
   title = {edgeTrpLib: Helper functions for EDGE transport calculations},
   author = {Alois Dirnaichner and Marianna Rottoli},
   year = {2022},
-  note = {R package version 1.6.0},
+  note = {R package version 1.6.1},
 }
 ```

--- a/inst/extdata/mapping_EDGECES.csv
+++ b/inst/extdata/mapping_EDGECES.csv
@@ -1,15 +1,32 @@
-sector,fuel,CES_node
-trn_pass,Electric,feelt_p_sm
-trn_pass,Liquids,fepet_p_sm
-trn_pass,NG,fegat_p_sm
-trn_pass,Hydrogen,feh2t_p_sm
-trn_freight,Electric,feelt_f_sm
-trn_freight,Liquids,fedie_f_sm
-trn_freight,NG,fegat_f_sm
-trn_freight,Hydrogen,feh2t_f_sm
-trn_aviation_intl,Electric,feelt_p_lo
-trn_aviation_intl,Liquids,fedie_p_lo
-trn_aviation_intl,Hydrogen,feh2t_p_lo
-trn_shipping_intl,Electric,feelt_f_lo
-trn_shipping_intl,Liquids,fedie_f_lo
-trn_shipping_intl,Hydrogen,feh2t_f_lo
+sector,subsector_L2,fuel,CES_node
+trn_pass,trn_pass_road_LDV,Electricity,feelt_p_sm
+trn_pass,trn_pass_road_LDV,Liquids,fepet_p_sm
+trn_pass,trn_pass_road_LDV,Hydrogen,feh2t_p_sm
+trn_pass,trn_pass_road_LDV,NG,fegat_p_sm
+trn_pass,Bus,Liquids,fedie_p_sm
+trn_pass,Bus,NG,fegat_p_sm
+trn_pass,trn_pass_road_bus,Liquids,fedie_p_sm
+trn_pass,trn_pass_road_bus,NG,fegat_p_sm
+trn_pass,Domestic Aviation_tmp_subsector_L2,Liquids,fedie_p_sm
+trn_pass,Domestic Aviation_tmp_subsector_L2,Hydrogen,feh2t_p_sm
+trn_pass,HSR_tmp_subsector_L2,Electric,feelt_p_sm
+trn_pass,Passenger Rail_tmp_subsector_L2,Electric,feelt_p_sm
+trn_pass,Passenger Rail_tmp_subsector_L2,Liquids,fedie_p_sm
+trn_pass,Passenger Rail_tmp_subsector_L2,Tech-Adv-Electric,feelt_p_sm
+trn_pass,Passenger Rail_tmp_subsector_L2,Tech-Adv-Liquid,fedie_p_sm
+trn_freight,trn_freight_road_tmp_subsector_L2,Liquids,fedie_f_sm
+trn_freight,trn_freight_road_tmp_subsector_L2,NG,fegat_f_sm
+trn_freight,Domestic Ship_tmp_subsector_L2,Liquids,fedie_f_sm
+trn_freight,Freight Rail_tmp_subsector_L2,Adv-Electric,feelt_f_sm
+trn_freight,Freight Rail_tmp_subsector_L2,Adv-Liquid,fedie_f_sm
+trn_freight,Freight Rail_tmp_subsector_L2,Coal,fedie_f_sm
+trn_freight,Freight Rail_tmp_subsector_L2,Electric,feelt_f_sm
+trn_freight,Freight Rail_tmp_subsector_L2,Liquids,fedie_f_sm
+trn_aviation_intl,International Aviation_tmp_subsector_L2,Liquids,fedie_p_lo
+trn_shipping_intl,International Ship_tmp_subsector_L2,Liquids,fedie_f_lo
+trn_freight,trn_freight_road_tmp_subsector_L2,Electric,feelt_f_sm
+trn_pass,Bus,Electric,feelt_p_sm
+trn_pass,trn_pass_road_bus,Electric,feelt_p_sm
+trn_freight,trn_freight_road_tmp_subsector_L2,FCEV,feh2t_f_sm
+trn_pass,Bus,FCEV,feh2t_p_sm
+trn_pass,trn_pass_road_bus,FCEV,feh2t_p_sm

--- a/inst/extdata/mapping_EDGECES.csv
+++ b/inst/extdata/mapping_EDGECES.csv
@@ -12,13 +12,9 @@ trn_pass,Domestic Aviation_tmp_subsector_L2,Hydrogen,feh2t_p_sm
 trn_pass,HSR_tmp_subsector_L2,Electric,feelt_p_sm
 trn_pass,Passenger Rail_tmp_subsector_L2,Electric,feelt_p_sm
 trn_pass,Passenger Rail_tmp_subsector_L2,Liquids,fedie_p_sm
-trn_pass,Passenger Rail_tmp_subsector_L2,Tech-Adv-Electric,feelt_p_sm
-trn_pass,Passenger Rail_tmp_subsector_L2,Tech-Adv-Liquid,fedie_p_sm
 trn_freight,trn_freight_road_tmp_subsector_L2,Liquids,fedie_f_sm
 trn_freight,trn_freight_road_tmp_subsector_L2,NG,fegat_f_sm
 trn_freight,Domestic Ship_tmp_subsector_L2,Liquids,fedie_f_sm
-trn_freight,Freight Rail_tmp_subsector_L2,Adv-Electric,feelt_f_sm
-trn_freight,Freight Rail_tmp_subsector_L2,Adv-Liquid,fedie_f_sm
 trn_freight,Freight Rail_tmp_subsector_L2,Coal,fedie_f_sm
 trn_freight,Freight Rail_tmp_subsector_L2,Electric,feelt_f_sm
 trn_freight,Freight Rail_tmp_subsector_L2,Liquids,fedie_f_sm
@@ -26,7 +22,5 @@ trn_aviation_intl,International Aviation_tmp_subsector_L2,Liquids,fedie_p_lo
 trn_shipping_intl,International Ship_tmp_subsector_L2,Liquids,fedie_f_lo
 trn_freight,trn_freight_road_tmp_subsector_L2,Electric,feelt_f_sm
 trn_pass,Bus,Electric,feelt_p_sm
-trn_pass,trn_pass_road_bus,Electric,feelt_p_sm
-trn_freight,trn_freight_road_tmp_subsector_L2,FCEV,feh2t_f_sm
-trn_pass,Bus,FCEV,feh2t_p_sm
-trn_pass,trn_pass_road_bus,FCEV,feh2t_p_sm
+trn_freight,trn_freight_road_tmp_subsector_L2,Hydrogen,feh2t_f_sm
+trn_pass,Bus,Hydrogen,feh2t_p_sm


### PR DESCRIPTION
Addresses the following issues:
- set elements were not correctly mapped in the new mapping (`fedie_p_sm` was missing).
- when calculating intensities, the technology dimension has been removed by mistake.