### PR TITLE
Ship all demandF_plot_XXX outputs with the correct dimensions

### DIFF
--- a/R/shares_intensities_and_demand.R
+++ b/R/shares_intensities_and_demand.R
@@ -81,10 +81,13 @@ Hybrid Electric,Liquids")
     demandF = merge(demand, MJ_km_base, all=FALSE, by = c("region", "sector", "year", "subsector_L3", "subsector_L2", "subsector_L1", "vehicle_type", "technology"))
 
     ## for the demand output we add non-motorized modes
-    demandF_plot_pkm = rbind(demandF, demandNM, use.names=T, fill=T)[,
-                              c("demand_F", "year","region", "sector", "subsector_L3", "subsector_L2","subsector_L1", "vehicle_type", "technology", "fuel")]
-    demandF_plot_mjkm = demandF[,
-                               c("MJ_km", "year","region", "sector", "subsector_L3", "subsector_L2","subsector_L1", "vehicle_type", "technology", "fuel")]
+    demandF_plot_pkm <- copy(unique(rbind(
+        demandF, demandNM, use.names=T, fill=T)[, c("demand_F", "year","region", "sector",
+                                                    "subsector_L3", "subsector_L2","subsector_L1",
+                                                    "vehicle_type", "technology")]))
+    demandF_plot_mjkm <- copy(demandF[, c("MJ_km", "year","region", "sector",
+                                    "subsector_L3", "subsector_L2","subsector_L1",
+                                    "vehicle_type", "technology", "fuel")])
 
     demandF[, demand_EJ:=demand_F # in Mpkm or Mtkm
             * 1e6 # in pkm or tkm
@@ -92,9 +95,9 @@ Hybrid Electric,Liquids")
             * 1e-12 # in EJ
             ]
 
-    ## demandF = demandF[,.(demand_EJ = sum(demand_EJ), demand_F = sum(demand_F)),
-    ##                   by = c("year","region", "sector", "subsector_L3", "subsector_L2","subsector_L1", "vehicle_type", "technology", "fuel")]
-    demandF_plot_EJ = copy(demandF)
+    demandF_plot_EJ <- copy(demandF[, c("demand_EJ", "year","region", "sector",
+                                        "subsector_L3", "subsector_L2","subsector_L1",
+                                        "vehicle_type", "technology", "fuel")])
 
     EDGE2CESmap <- fread(system.file("extdata", "mapping_EDGECES.csv", package = "edgeTrpLib"))
     ## first I need to merge with a mapping that represents how the entries match to the CES


### PR DESCRIPTION
removing fuel as a category from pkm outputs (which is misleading, as
ES demands can not be split for Electricity and Liquids inputs for PHEVs)